### PR TITLE
[FEAT] 주문서 UX 개선 및 카드/전화번호 입력 개선

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,7 @@ version: "3.9"
 services:
   frontend:
     container_name: cotree-frontend-dev
+    image: cotree-frontend:dev
     build:
       context: .
       dockerfile: Dockerfile.dev

--- a/src/features/order/model/schema/orderForm.schema.ts
+++ b/src/features/order/model/schema/orderForm.schema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 export const orderFormSchema = z.object({
+  recipientName: z.string().min(1, "이름을 입력해주세요"),
+  recipientPhone: z.string().regex(/^010\d{8}$/, "전화번호 형식이 올바르지 않습니다"),
   cardNumber: z.string().min(16, "카드 번호는 16자리를 입력해주세요"),
   cardType: z.string().min(1, "카드사를 선택해주세요"),
   installment: z.string().min(1, "할부 개월을 선택해주세요"),

--- a/src/features/order/model/types/daumPostCode.ts
+++ b/src/features/order/model/types/daumPostCode.ts
@@ -1,0 +1,7 @@
+export interface DaumPostcodeData {
+  address: string;
+  addressType: "R" | "J";
+  bname: string;
+  buildingName: string;
+  zonecode: string;
+}

--- a/src/features/order/ui/index.tsx
+++ b/src/features/order/ui/index.tsx
@@ -1,5 +1,6 @@
-export { default as OrderPaymentCardInformationForm } from "./orderPaymentCardInformationForm";
+export { default as OrderPaymentCardInformationFields } from "./orderPaymentCardInformationFields";
 export { default as OrderAgreementConfirmationCheckbox } from "./orderAgreementConfirmationCheckbox";
 export { default as OrderPaymentActionBar } from "./orderPaymentActionBar";
 export { default as OrderShippingAddressPostcode } from "./orderShippingAddressPostCode";
 export { default as OrderShippingAddressRegistrationSection } from "./orderShippingAddressRegistrationSection";
+export { default as OrderRecipientFields } from "./orderRecipientFields";

--- a/src/features/order/ui/orderPaymentCardInformationFields.tsx
+++ b/src/features/order/ui/orderPaymentCardInformationFields.tsx
@@ -1,22 +1,32 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/shared/components/ui/select";
 import { Controller, useFormContext } from "react-hook-form";
 
-export default function OrderPaymentCardInformationForm() {
+export default function OrderPaymentCardInformationFields() {
   const { setValue, control, formState } = useFormContext();
   const { errors } = formState;
 
   const [segments, setSegments] = useState(["", "", "", ""]);
+  const refs = [
+    useRef<HTMLInputElement>(null),
+    useRef<HTMLInputElement>(null),
+    useRef<HTMLInputElement>(null),
+    useRef<HTMLInputElement>(null),
+  ];
 
   const handleSegmentChange = (value: string, index: number) => {
+    const newValue = value.replace(/\D/g, "").slice(0, 4);
     const newSegments = [...segments];
-    newSegments[index] = value.replace(/\D/g, "").slice(0, 4);
+    newSegments[index] = newValue;
     setSegments(newSegments);
 
-    const joined = newSegments.join("");
-    setValue("cardNumber", joined);
+    setValue("cardNumber", newSegments.join(""));
+
+    if (newValue.length === 4 && index < 3) {
+      refs[index + 1].current?.focus();
+    }
   };
 
   return (
@@ -27,6 +37,7 @@ export default function OrderPaymentCardInformationForm() {
           {segments.map((val, i) => (
             <Input
               key={i}
+              ref={refs[i]}
               placeholder="****"
               maxLength={4}
               className="w-1/4 placeholder:text-muted-foreground/50"

--- a/src/features/order/ui/orderRecipientFields.tsx
+++ b/src/features/order/ui/orderRecipientFields.tsx
@@ -1,0 +1,72 @@
+import { useRef, useState } from "react";
+import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
+import { useFormContext } from "react-hook-form";
+
+export default function OrderRecipientFields() {
+  const { setValue, register, formState } = useFormContext();
+  const { errors } = formState;
+
+  const [segments, setSegments] = useState(["", "", ""]);
+  const refs = [useRef<HTMLInputElement>(null), useRef<HTMLInputElement>(null), useRef<HTMLInputElement>(null)];
+
+  const handleSegmentChange = (value: string, index: number) => {
+    const sanitized = value.replace(/\D/g, "").slice(0, index === 0 ? 3 : 4);
+    const updated = [...segments];
+    updated[index] = sanitized;
+    setSegments(updated);
+
+    const fullNumber = updated.join("");
+    setValue("recipientPhone", fullNumber);
+
+    if (sanitized.length === (index === 0 ? 3 : 4) && index < 2) {
+      refs[index + 1].current?.focus();
+    }
+  };
+
+  return (
+    <section className="space-y-4">
+      <h2 className="font-semibold text-lg">받는 사람 정보</h2>
+
+      <div className="space-y-2">
+        <div>
+          <Label htmlFor="recipientName" className="block text-sm font-medium mb-1">
+            이름
+          </Label>
+          <Input
+            id="recipientName"
+            {...register("recipientName")}
+            placeholder="홍길동"
+            className="w-full placeholder:text-muted-foreground/50"
+          />
+          {errors.recipientName && (
+            <p className="text-sm text-destructive mt-1">{errors.recipientName.message as string}</p>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="recipientPhone" className="block text-sm font-medium mb-1">
+            전화번호
+          </Label>
+          <div className="flex gap-2">
+            {segments.map((val, i) => (
+              <Input
+                key={i}
+                inputMode="numeric"
+                placeholder={i === 0 ? "010" : "1234"}
+                maxLength={i === 0 ? 3 : 4}
+                className="w-1/3 placeholder:text-muted-foreground/50"
+                value={val}
+                ref={refs[i]}
+                onChange={(e) => handleSegmentChange(e.target.value, i)}
+              />
+            ))}
+          </div>
+          {errors.recipientPhone && (
+            <p className="text-sm text-destructive mt-1">{errors.recipientPhone.message as string}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/order/ui/orderShippingAddressPostCode.tsx
+++ b/src/features/order/ui/orderShippingAddressPostCode.tsx
@@ -1,5 +1,6 @@
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/shared/components/ui/dialog";
 import DaumPostcodeEmbed from "react-daum-postcode";
+import { DaumPostcodeData } from "@/features/order/model/types/daumPostCode";
 
 interface OrderShippingAddressPostcodeProps {
   open: boolean;
@@ -8,24 +9,23 @@ interface OrderShippingAddressPostcodeProps {
 }
 
 export default function OrderShippingAddressPostcode({ open, setOpen, onSelect }: OrderShippingAddressPostcodeProps) {
+  const handleComplete = (data: DaumPostcodeData) => {
+    const extra = data.addressType === "R" ? [data.bname, data.buildingName].filter(Boolean).join(", ") : "";
+    const full = extra ? `${data.address} (${extra})` : data.address;
+    onSelect(full);
+    setOpen(false);
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="p-0 w-full max-w-limit h-screen max-h-full border-0 bg-background flex flex-col">
+      <DialogContent className="p-0 w-full max-w-limit h-screen max-h-full bg-background flex flex-col rounded-none">
         <DialogTitle className="sr-only">주소 검색</DialogTitle>
         <DialogDescription className="sr-only">주소를 검색해 배송지로 등록하세요</DialogDescription>
 
         <div className="h-12 shrink-0 flex items-center justify-end px-4"></div>
 
         <div className="flex-1 overflow-hidden">
-          <DaumPostcodeEmbed
-            onComplete={(data: any) => {
-              const extra = data.addressType === "R" ? [data.bname, data.buildingName].filter(Boolean).join(", ") : "";
-              const full = extra ? `${data.address} (${extra})` : data.address;
-              onSelect(full);
-              setOpen(false);
-            }}
-            style={{ width: "100%", height: "100%" }}
-          />
+          <DaumPostcodeEmbed onComplete={handleComplete} style={{ width: "100%", height: "100%" }} />
         </div>
       </DialogContent>
     </Dialog>

--- a/src/pages/order/create/index.tsx
+++ b/src/pages/order/create/index.tsx
@@ -3,7 +3,7 @@ import OrderCreateView from "./orderCreateView";
 
 export default function OrderCreatePage() {
   return (
-    <HeaderHomeLayout>
+    <HeaderHomeLayout title="주문/결제">
       <OrderCreateView />
     </HeaderHomeLayout>
   );

--- a/src/pages/order/create/orderCreateView.tsx
+++ b/src/pages/order/create/orderCreateView.tsx
@@ -4,7 +4,8 @@ import { OrderPaymentMethodButtonList, OrderPaymentTypeRadioGroup, OrderProductL
 import {
   OrderAgreementConfirmationCheckbox,
   OrderPaymentActionBar,
-  OrderPaymentCardInformationForm,
+  OrderPaymentCardInformationFields,
+  OrderRecipientFields,
   OrderShippingAddressPostcode,
   OrderShippingAddressRegistrationSection,
 } from "@/features/order/ui";
@@ -58,9 +59,11 @@ export default function OrderCreateView() {
   });
 
   const onSubmit = (data: OrderFormValues) => {
-    const { cardNumber, shippingAddress, products, totalAmount } = data;
+    const { recipientName, recipientPhone, cardNumber, shippingAddress, products, totalAmount } = data;
 
     const payload = {
+      recipientName,
+      recipientPhone,
       cardNumber,
       shippingAddress,
       products,
@@ -78,7 +81,7 @@ export default function OrderCreateView() {
             <OrderShippingAddressPostcode open={open} setOpen={setOpen} onSelect={onSelect} />
           )}
         </OrderShippingAddressRegistrationSection>
-
+        <OrderRecipientFields />
         <OrderProductListSection products={products} />
         <section className="space-y-4">
           <h2 className="font-semibold text-lg">결제수단</h2>
@@ -93,7 +96,7 @@ export default function OrderCreateView() {
             ]}
           />
 
-          <OrderPaymentCardInformationForm />
+          <OrderPaymentCardInformationFields />
         </section>
 
         <section className="space-y-3">


### PR DESCRIPTION
<!-- 제목 입력하기 -->
<!-- [FEAT/CHORE/FIX/DOCS/REFACTOR/#이슈번호] 기능제목 -->
[FEAT] 주문서 UX 개선 및 카드/전화번호 입력 개선

<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
- `feature/order` -> `main`

## 🔗변경 사항
 - 카드번호 입력을 4칸 분할 및 자동 포커스 이동 처리
 - 전화번호 입력을 3칸 분할로 개선
 - react-hook-form과 통합하여 카드번호/전화번호를 단일 필드로 변환

## ✔️테스트
 - [x] 카드번호 4칸 입력 후 자동 이동 동작 확인
 - [x] 전화번호 3칸 입력 시 전체 값 생성됨 확인
 - [x] 유효성 검사 오류 메시지 노출 확인
 - [x] 주문서 전체 시각 구조 자연스럽게 동작 확인

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
