### PR TITLE
[FEAT] 장바구니 페이지 로직 및 UI 정리

### DIFF
--- a/src/app/appRouter.tsx
+++ b/src/app/appRouter.tsx
@@ -4,6 +4,7 @@ import CategoryPage from "@/pages/category";
 import ProductDetailPage from "@/pages/productDetail";
 import OrderCreatePage from "@/pages/order/create";
 import MyPage from "@/pages/mypage";
+import ShoppingCartPage from "@/pages/shoppingCart";
 
 export default function AppRouter() {
   return (
@@ -13,6 +14,7 @@ export default function AppRouter() {
         <Route path="/category" element={<CategoryPage />} />
         <Route path="/product/:id" element={<ProductDetailPage />} />
         <Route path="/order/:id" element={<OrderCreatePage />} />
+        <Route path="/cart" element={<ShoppingCartPage />} />
         <Route path="/mypage" element={<MyPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/entities/cart/model/index.ts
+++ b/src/entities/cart/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/entities/cart/model/types.ts
+++ b/src/entities/cart/model/types.ts
@@ -1,0 +1,10 @@
+export interface CartItem {
+  id: number;
+  image: string;
+  name: string;
+  brand: string;
+  price: number;
+  discount: number;
+  quantity: number;
+  isGreen: boolean;
+}

--- a/src/entities/cart/ui/cartProductItem.tsx
+++ b/src/entities/cart/ui/cartProductItem.tsx
@@ -1,0 +1,61 @@
+import { CartItem } from "@/entities/cart/model";
+import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
+import { Trash2 } from "lucide-react";
+import { Link } from "react-router-dom";
+
+interface CartProductItemProps {
+  item: CartItem & { selected: boolean };
+  onSelect: (checked: boolean | "indeterminate") => void;
+  onDelete: () => void;
+}
+
+export default function CartProductItem({ item, onSelect, onDelete }: CartProductItemProps) {
+  const finalPrice = item.price - item.discount;
+  const point = item.isGreen ? Math.floor(finalPrice * 0.05 * item.quantity) : 0;
+
+  return (
+    <div className="border-b px-4 py-4">
+      <div className="flex items-start gap-4">
+        <Checkbox checked={item.selected} onCheckedChange={onSelect} className="shrink-0" />
+
+        <img src={item.image} alt={item.name} className="w-32 h-32 object-cover rounded-md border shrink-0" />
+
+        <div className="flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            {item.isGreen && <Badge className="text-xs bg-primary text-primary-foreground">친환경</Badge>}
+            <span className="text-sm font-semibold text-foreground">{item.brand}</span>
+          </div>
+
+          <Link to={`/product/${item.id}`} className="block">
+            <div className="text-sm font-medium text-foreground leading-snug line-clamp-2 hover:underline">
+              {item.name}
+            </div>
+          </Link>
+
+          <div className="text-xs text-muted-foreground">수량: {item.quantity}</div>
+
+          <div className="mt-1">
+            <div className="text-base font-bold text-foreground">{(finalPrice * item.quantity).toLocaleString()}원</div>
+            {item.discount > 0 && (
+              <div className="text-xs text-gray-400 line-through">
+                {(item.price * item.quantity).toLocaleString()}원
+              </div>
+            )}
+          </div>
+
+          {item.isGreen && (
+            <div className="text-xs text-emerald-600 font-medium mt-1">
+              🌿 그린포인트 {point.toLocaleString()}P 적립 예정
+            </div>
+          )}
+        </div>
+
+        <Button size="icon" variant="link" className="shrink-0 mt-1 cursor-pointer" onClick={onDelete}>
+          <Trash2 size={16} className="cursor-pointer" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/entities/cart/ui/cartProductList.tsx
+++ b/src/entities/cart/ui/cartProductList.tsx
@@ -1,0 +1,23 @@
+import { CartItem } from "../model";
+import CartProductItem from "./cartProductItem";
+
+interface CartProductListProps {
+  items: (CartItem & { selected: boolean })[];
+  onSelectItem: (id: number, checked: boolean | "indeterminate") => void;
+  onDeleteItem: (id: number) => void;
+}
+
+export default function CartProductList({ items, onSelectItem, onDeleteItem }: CartProductListProps) {
+  return (
+    <div>
+      {items.map((item) => (
+        <CartProductItem
+          key={item.id}
+          item={item}
+          onSelect={(checked) => onSelectItem(item.id, checked)}
+          onDelete={() => onDeleteItem(item.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/entities/cart/ui/cartSummary.tsx
+++ b/src/entities/cart/ui/cartSummary.tsx
@@ -1,0 +1,35 @@
+interface CartSummaryProps {
+  totalPrice: number;
+  totalDiscount: number;
+  finalTotalPrice: number;
+  totalPoints: number;
+}
+
+export default function CartSummary({ totalPrice, totalDiscount, finalTotalPrice, totalPoints }: CartSummaryProps) {
+  return (
+    <div className="px-4 py-3 space-y-2 border-b text-base">
+      <div className="flex justify-between">
+        <span>총 상품금액</span>
+        <span>{totalPrice.toLocaleString()}원</span>
+      </div>
+      <div className="flex justify-between">
+        <span>총 배송비</span>
+        <span>0원</span>
+      </div>
+      <div className="flex justify-between">
+        <span>총 할인금액</span>
+        <span className="text-primary">- {totalDiscount.toLocaleString()}원</span>
+      </div>
+      <div className="flex justify-between font-bold text-lg text-orange-600">
+        <span>총 주문금액</span>
+        <span>{finalTotalPrice.toLocaleString()}원</span>
+      </div>
+      {totalPoints > 0 && (
+        <div className="flex justify-between text-sm text-emerald-700 font-medium">
+          <span>총 적립 포인트</span>
+          <span>{totalPoints.toLocaleString()}P</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/entities/cart/ui/index.ts
+++ b/src/entities/cart/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as CartProductItem } from "./cartProductItem";
+export { default as CartProductList } from "./cartProductList";
+export { default as CartSummary } from "./cartSummary";

--- a/src/features/cart/ui/cartEmptyState.tsx
+++ b/src/features/cart/ui/cartEmptyState.tsx
@@ -1,0 +1,17 @@
+import { Button } from "@/shared/components/ui/button";
+import { ShoppingCart } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+export default function CartEmptyState() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-muted-foreground text-sm">
+      <ShoppingCart className="w-10 h-10 mb-4 text-gray-400" />
+      <p>장바구니에 담긴 상품이 없습니다.</p>
+      <Button className="mt-4" variant="outline" onClick={() => navigate("/")}>
+        쇼핑하러 가기
+      </Button>
+    </div>
+  );
+}

--- a/src/features/cart/ui/cartOrderActionBar.tsx
+++ b/src/features/cart/ui/cartOrderActionBar.tsx
@@ -1,0 +1,19 @@
+import { Button } from "@/shared/components/ui/button";
+
+interface CartOrderActionBarProps {
+  selectedCount: number;
+}
+
+export default function CartOrderActionBar({ selectedCount }: CartOrderActionBarProps) {
+  return (
+    <div className="w-full max-w-limit fixed bottom-0 left-1/2 -translate-x-1/2 bg-background border-t border-border z-50">
+      <div className="max-w-limit mx-auto px-4 py-4">
+        <div className="w-full flex gap-3">
+          <Button className="w-full h-12 cursor-pointer" disabled={selectedCount === 0}>
+            {selectedCount > 0 ? `${selectedCount}개 상품 주문하기` : "상품을 선택해주세요"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cart/ui/index.ts
+++ b/src/features/cart/ui/index.ts
@@ -1,0 +1,2 @@
+export { default as CartEmptyState } from "./cartEmptyState";
+export { default as CartOrderActionBar } from "./cartOrderActionBar";

--- a/src/pages/shoppingCart/index.tsx
+++ b/src/pages/shoppingCart/index.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { HeaderHomeLayout } from "@/shared/layout";
+import { Checkbox } from "@/shared/components/ui/checkbox";
+import { CartEmptyState, CartOrderActionBar } from "@/features/cart/ui";
+import { CartProductList, CartSummary } from "@/entities/cart/ui";
+import { CartItem } from "@/entities/cart/model";
+
+const initialCartItems = [
+  {
+    id: 1,
+    image: "https://placehold.co/120x120?text=유기농+사과",
+    name: "유기농 사과 1kg",
+    brand: "로컬팜",
+    price: 5600,
+    discount: 600,
+    quantity: 1,
+    isGreen: true,
+  },
+  {
+    id: 2,
+    image: "https://placehold.co/120x120?text=방울토마토",
+    name: "유기농 방울토마토 500g",
+    brand: "그린팜",
+    price: 4200,
+    discount: 200,
+    quantity: 2,
+    isGreen: true,
+  },
+  {
+    id: 3,
+    image: "https://placehold.co/120x120?text=바나나",
+    name: "바나나 1송이",
+    brand: "프레시마트",
+    price: 3500,
+    discount: 0,
+    quantity: 1,
+    isGreen: false,
+  },
+];
+
+export default function ShoppingCartPage() {
+  const [cartItems, setCartItems] = useState<(CartItem & { selected: boolean })[]>(
+    initialCartItems.map((item) => ({ ...item, selected: true }))
+  );
+
+  const isAllSelected = cartItems.length > 0 && cartItems.every((item) => item.selected);
+  const selectedCount = cartItems.filter((item) => item.selected).length;
+
+  const handleSelectAll = (checked: boolean | "indeterminate") => {
+    setCartItems((items) => items.map((item) => ({ ...item, selected: checked === true })));
+  };
+
+  const handleSelectItem = (id: number, checked: boolean | "indeterminate") => {
+    setCartItems((prev) => prev.map((item) => (item.id === id ? { ...item, selected: checked === true } : item)));
+  };
+
+  const handleDeleteItem = (id: number) => {
+    setCartItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const selectedItems = cartItems.filter((item) => item.selected);
+  const totalPrice = selectedItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const totalDiscount = selectedItems.reduce((sum, item) => sum + item.discount * item.quantity, 0);
+  const finalTotalPrice = totalPrice - totalDiscount;
+  const totalPoints = selectedItems.reduce((sum, item) => {
+    const point = item.isGreen ? Math.floor((item.price - item.discount) * 0.05 * item.quantity) : 0;
+    return sum + point;
+  }, 0);
+
+  return (
+    <HeaderHomeLayout title="장바구니">
+      {cartItems.length === 0 ? (
+        <CartEmptyState />
+      ) : (
+        <>
+          <div className="flex items-center justify-between border-b px-4 py-3">
+            <div className="flex items-center gap-2">
+              <Checkbox checked={isAllSelected} onCheckedChange={handleSelectAll} />
+              <span className="text-sm font-medium">전체상품 ({cartItems.length})</span>
+            </div>
+          </div>
+
+          <CartProductList items={cartItems} onSelectItem={handleSelectItem} onDeleteItem={handleDeleteItem} />
+
+          <CartSummary
+            totalPrice={totalPrice}
+            totalDiscount={totalDiscount}
+            finalTotalPrice={finalTotalPrice}
+            totalPoints={totalPoints}
+          />
+
+          <CartOrderActionBar selectedCount={selectedCount} />
+        </>
+      )}
+    </HeaderHomeLayout>
+  );
+}

--- a/src/shared/layout/commonLayout.tsx
+++ b/src/shared/layout/commonLayout.tsx
@@ -37,7 +37,7 @@ export default function CommonLayout({ children, title = "" }: CommonLayoutProps
               <span className="sr-only">Search</span>
               <Search className="!w-6 !h-6 text-black" />
             </Button>
-            <Link to={"/"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
+            <Link to={"/cart"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
               <span className="sr-only">ShoppingCart</span>
               <ShoppingCart className="!w-6 !h-6 text-black" />
             </Link>

--- a/src/shared/layout/headerBackLayout.tsx
+++ b/src/shared/layout/headerBackLayout.tsx
@@ -25,7 +25,7 @@ export default function HeaderBackLayout({ children, title = "" }: HeaderBackLay
           </div>
 
           <div className="absolute bottom-0 right-4 top-0 flex flex-row items-center justify-center gap-4">
-            <Link to={"#"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
+            <Link to={"/cart"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
               <span className="sr-only">ShoppingCart</span>
               <ShoppingCart className="!w-6 !h-6 text-black" />
             </Link>


### PR DESCRIPTION
<!-- 제목 입력하기 -->
<!-- [FEAT/CHORE/FIX/DOCS/REFACTOR] 기능제목 -->
[FEAT] 장바구니 페이지 로직 및 UI 정리

<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
 - `feat/shoppingBasket` -> `main`

## 🔗변경 사항
- 장바구니 상태 로직을 페이지 상단에서 모두 관리
- 이후 커스텀훅으로 뺄지는 고민해봐야할듯

## ✔️테스트
- [x] 전체 선택/해제 동작 정상
- [x] 상품 개별 선택/삭제 동작 정상
- [x] 총 주문 금액, 적립 포인트 정확히 반영됨
- [x] 선택된 상품 0개일 때 버튼 비활성화 처리

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
