### PR TITLE
[FEAT] 카카오 로그인, 프론트에서 하드코딩 로그인여부 체크

### DIFF
--- a/public/kakao-icon.svg
+++ b/public/kakao-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 4C7.581 4 4 6.903 4 10.444C4 12.786 5.615 14.836 8 15.899L7.001 19.555C6.94 19.752 7.194 19.907 7.366 19.786L11.473 16.972C11.647 16.992 11.822 17 12 17C16.418 17 20 14.097 20 10.444C20 6.903 16.418 4 12 4Z" fill="black"/>
+</svg> 

--- a/src/app/appRoute.tsx
+++ b/src/app/appRoute.tsx
@@ -1,0 +1,17 @@
+import CategoryPage from "@/pages/category";
+import HomePage from "@/pages/home";
+import LoginPage from "@/pages/login";
+import MyPage from "@/pages/mypage";
+import OrderCreatePage from "@/pages/order/create";
+import ProductDetailPage from "@/pages/productDetail";
+import ShoppingCartPage from "@/pages/shoppingCart";
+
+export const appRoutes = [
+  { path: "/", element: <HomePage />, isPublic: true },
+  { path: "/category", element: <CategoryPage />, isPublic: true },
+  { path: "/product/:id", element: <ProductDetailPage />, isPublic: true },
+  { path: "/order/:id", element: <OrderCreatePage />, isPublic: false },
+  { path: "/cart", element: <ShoppingCartPage />, isPublic: false },
+  { path: "/mypage", element: <MyPage />, isPublic: false },
+  { path: "/login", element: <LoginPage />, isPublic: true },
+];

--- a/src/app/appRouter.tsx
+++ b/src/app/appRouter.tsx
@@ -1,22 +1,18 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import HomePage from "@/pages/home";
-import CategoryPage from "@/pages/category";
-import ProductDetailPage from "@/pages/productDetail";
-import OrderCreatePage from "@/pages/order/create";
-import MyPage from "@/pages/mypage";
-import ShoppingCartPage from "@/pages/shoppingCart";
+import { appRoutes } from "./appRoute";
+import { AuthProvider } from "@/features/auth/provider";
+import { ProtectedRoute } from "@/features/auth/config";
 
 export default function AppRouter() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/category" element={<CategoryPage />} />
-        <Route path="/product/:id" element={<ProductDetailPage />} />
-        <Route path="/order/:id" element={<OrderCreatePage />} />
-        <Route path="/cart" element={<ShoppingCartPage />} />
-        <Route path="/mypage" element={<MyPage />} />
-      </Routes>
+      <AuthProvider>
+        <Routes>
+          {appRoutes.map(({ path, element, isPublic }) => (
+            <Route key={path} path={path} element={<ProtectedRoute isPublic={isPublic}>{element}</ProtectedRoute>} />
+          ))}
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/src/features/auth/config/index.ts
+++ b/src/features/auth/config/index.ts
@@ -1,0 +1,1 @@
+export { default as ProtectedRoute } from "./protectedRoute";

--- a/src/features/auth/config/protectedRoute.tsx
+++ b/src/features/auth/config/protectedRoute.tsx
@@ -1,0 +1,19 @@
+import { useLocation, Navigate } from "react-router-dom";
+import { useAuth } from "../hooks";
+
+interface ProtectedRouteProps {
+  isPublic?: boolean;
+  children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ isPublic = false, children }: ProtectedRouteProps) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isPublic && !isAuthenticated) {
+    const redirectPath = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?redirect=${redirectPath}`} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/features/auth/context/authContext.tsx
+++ b/src/features/auth/context/authContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+export interface AuthContextType {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+  authenticatedNavigate: (to: string) => void;
+  openAuthDrawer: (to: string) => void;
+}
+
+export const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/features/auth/context/index.ts
+++ b/src/features/auth/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./authContext";

--- a/src/features/auth/hooks/index.ts
+++ b/src/features/auth/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useAuth";
+export * from "./useAuthenticateNavigate";

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { AuthContext } from "../context";
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error("useAuth not found!");
+  return context;
+};

--- a/src/features/auth/hooks/useAuthenticateNavigate.ts
+++ b/src/features/auth/hooks/useAuthenticateNavigate.ts
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "./useAuth";
+
+const protectedPaths = ["/cart", "/mypage", "/order"];
+
+export const useAuthenticatedNavigate = () => {
+  const { isAuthenticated, openAuthDrawer } = useAuth();
+  const navigate = useNavigate();
+
+  return (to: string | number, options?: { replace?: boolean }) => {
+    if (typeof to === "string") {
+      const isProtected = protectedPaths.some((p) => to.startsWith(p));
+      if (isProtected && !isAuthenticated) {
+        openAuthDrawer(to);
+        return;
+      }
+      navigate(to, options);
+    } else {
+      navigate(to);
+    }
+  };
+};

--- a/src/features/auth/provider/authProvider.tsx
+++ b/src/features/auth/provider/authProvider.tsx
@@ -1,0 +1,75 @@
+import { ReactNode, useMemo, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { KakaoLoginBottomSheet } from "@/features/auth/ui";
+import { AuthContext } from "../context";
+
+const protectedPaths = [/^\/cart$/, /^\/mypage$/, /^\/order\/\d+$/];
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
+
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [pendingNavigation, setPendingNavigation] = useState<{
+    to: string;
+  } | null>(null);
+
+  const isProtectedPath = (path: string) => protectedPaths.some((regex) => regex.test(path));
+
+  const openAuthDrawer = useCallback((to: string) => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+
+    setPendingNavigation({ to });
+    setIsOpen(true);
+  }, []);
+
+  const authenticatedNavigate = useCallback(
+    (to: string) => {
+      if (isProtectedPath(to) && !isAuthenticated) {
+        openAuthDrawer(to);
+        return;
+      }
+      navigate(to);
+    },
+    [isAuthenticated, navigate, openAuthDrawer]
+  );
+
+  const login = useCallback(() => {
+    setIsAuthenticated(true);
+    setIsOpen(false);
+
+    if (pendingNavigation) {
+      navigate(pendingNavigation.to);
+      setPendingNavigation(null);
+    }
+  }, [pendingNavigation, navigate]);
+
+  const logout = useCallback(() => {
+    setIsAuthenticated(false);
+  }, []);
+
+  const onClose = useCallback(() => {
+    setIsOpen(false);
+    setPendingNavigation(null);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      isAuthenticated,
+      login,
+      logout,
+      authenticatedNavigate,
+      openAuthDrawer,
+    }),
+    [isAuthenticated, login, logout, authenticatedNavigate, openAuthDrawer]
+  );
+
+  return (
+    <AuthContext.Provider value={contextValue}>
+      {children}
+      <KakaoLoginBottomSheet isOpen={isOpen} onClose={onClose} onLogin={login} />
+    </AuthContext.Provider>
+  );
+}

--- a/src/features/auth/provider/index.ts
+++ b/src/features/auth/provider/index.ts
@@ -1,0 +1,1 @@
+export { default as AuthProvider } from "./authProvider";

--- a/src/features/auth/ui/authLink.tsx
+++ b/src/features/auth/ui/authLink.tsx
@@ -1,0 +1,20 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../hooks";
+
+interface AuthLinkProps extends React.ComponentProps<typeof Link> {
+  to: string;
+}
+
+export default function AuthLink({ to, ...props }: AuthLinkProps) {
+  const { isAuthenticated, authenticatedNavigate } = useAuth();
+  const isProtected = ["/cart", "/mypage", "/order"].some((p) => to.startsWith(p));
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (isProtected && !isAuthenticated) {
+      e.preventDefault();
+      authenticatedNavigate(to);
+    }
+  };
+
+  return <Link to={to} onClick={handleClick} {...props} />;
+}

--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,0 +1,2 @@
+export { default as KakaoLoginBottomSheet } from "./kakaoLoginBottomSheet";
+export { default as AuthLink } from "./authLink";

--- a/src/features/auth/ui/kakaoLoginBottomSheet.tsx
+++ b/src/features/auth/ui/kakaoLoginBottomSheet.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/shared/components/ui/drawer";
+
+interface KakaoLoginBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLogin: () => void;
+}
+
+export default function KakaoLoginBottomSheet({ isOpen, onClose, onLogin }: KakaoLoginBottomSheetProps) {
+  return (
+    <Drawer open={isOpen} onOpenChange={onClose}>
+      <DrawerContent className="w-full max-w-limit mx-auto bg-background z-50" tabIndex={-1}>
+        <DrawerHeader>
+          <DrawerTitle className="text-xl text-foreground">로그인</DrawerTitle>
+          <DrawerDescription className="text-sm text-muted-foreground">
+            로그인하여 더 많은 기능을 이용해보세요.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter>
+          <div className="flex flex-col gap-4 p-4">
+            <Button
+              className="relative w-full flex items-center justify-center p-4 border border-transparent text-base font-bold rounded-md text-black bg-[#FEE500] hover:bg-[#FEE500]/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FEE500]"
+              size="lg"
+              onClick={onLogin}
+            >
+              <img src="/kakao-icon.svg" alt="카카오 로고" className="w-5 h-5 mr-2" width={20} height={20} />
+              카카오로 로그인하기
+            </Button>
+            <Button className="w-full px-4 py-3 text-gray-900 bg-gray-100 rounded-md hover:bg-gray-200" size="lg">
+              게스트 계정으로 로그인하기
+            </Button>
+            <Button
+              className="w-full px-4 py-3 text-gray-900 bg-gray-100 rounded-md hover:bg-gray-200"
+              size="lg"
+              onClick={onClose}
+            >
+              나중에 하기
+            </Button>
+          </div>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/features/cart/ui/cartEmptyState.tsx
+++ b/src/features/cart/ui/cartEmptyState.tsx
@@ -1,9 +1,9 @@
+import { useAuthenticatedNavigate } from "@/features/auth/hooks";
 import { Button } from "@/shared/components/ui/button";
 import { ShoppingCart } from "lucide-react";
-import { useNavigate } from "react-router-dom";
 
 export default function CartEmptyState() {
-  const navigate = useNavigate();
+  const navigate = useAuthenticatedNavigate();
 
   return (
     <div className="flex flex-col items-center justify-center py-20 text-muted-foreground text-sm w-full max-w-limit">

--- a/src/features/cart/ui/cartOrderActionBar.tsx
+++ b/src/features/cart/ui/cartOrderActionBar.tsx
@@ -1,3 +1,4 @@
+import { useAuthenticatedNavigate } from "@/features/auth/hooks";
 import { Button } from "@/shared/components/ui/button";
 
 interface CartOrderActionBarProps {
@@ -5,11 +6,19 @@ interface CartOrderActionBarProps {
 }
 
 export default function CartOrderActionBar({ selectedCount }: CartOrderActionBarProps) {
+  const navigate = useAuthenticatedNavigate();
+
+  const handleOrderClick = () => {
+    if (selectedCount > 0) {
+      navigate("/order/1"); // 추후 동적 orderId로 변경 가능
+    }
+  };
+
   return (
     <div className="w-full max-w-limit fixed bottom-0 left-1/2 -translate-x-1/2 bg-background border-t border-border z-50">
       <div className="max-w-limit mx-auto px-4 py-4">
         <div className="w-full flex gap-3">
-          <Button className="w-full h-12 cursor-pointer" disabled={selectedCount === 0}>
+          <Button className="w-full h-12 cursor-pointer" disabled={selectedCount === 0} onClick={handleOrderClick}>
             {selectedCount > 0 ? `${selectedCount}개 상품 주문하기` : "상품을 선택해주세요"}
           </Button>
         </div>

--- a/src/features/product/ui/productPurchaseActionBar.tsx
+++ b/src/features/product/ui/productPurchaseActionBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/shared/components/ui/button";
 import { ShoppingCart } from "lucide-react";
+import { useAuth } from "@/features/auth/hooks";
 
 interface ProductPurchaseActionBarProps {
   product: {
@@ -16,7 +17,16 @@ interface ProductPurchaseActionBarProps {
 }
 
 export default function ProductPurchaseActionBar({ product, children }: ProductPurchaseActionBarProps) {
+  const { isAuthenticated, openAuthDrawer } = useAuth();
+
   const [open, setOpen] = useState(false);
+
+  const handleAddToCart = () => {
+    if (!isAuthenticated) {
+      openAuthDrawer("/cart");
+      return;
+    }
+  };
 
   const handleOpenDrawer = () => {
     if (document.activeElement instanceof HTMLElement) {
@@ -33,6 +43,7 @@ export default function ProductPurchaseActionBar({ product, children }: ProductP
             <Button
               className="w-1/4 h-12 rounded-lg border border-border bg-background flex items-center justify-center cursor-pointer"
               variant="link"
+              onClick={handleAddToCart}
             >
               <ShoppingCart className="w-5 h-5 text-muted-foreground" />
             </Button>

--- a/src/features/product/ui/productPurchaseDrawer.tsx
+++ b/src/features/product/ui/productPurchaseDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription } from "@/shared/components/ui/drawer";
 import { Button } from "@/shared/components/ui/button";
+import { useAuth, useAuthenticatedNavigate } from "@/features/auth/hooks";
 
 interface ProductPurchaseDrawerProps {
   open: boolean;
@@ -13,8 +14,30 @@ interface ProductPurchaseDrawerProps {
 }
 
 export default function ProductPurchaseDrawer({ open, setOpen, product }: ProductPurchaseDrawerProps) {
+  const { isAuthenticated, openAuthDrawer } = useAuth();
+
   const [quantity, setQuantity] = useState(1);
   const finalPrice = product.price - product.discount;
+  const navigate = useAuthenticatedNavigate();
+
+  const handlePurchase = () => {
+    setOpen(false);
+    setTimeout(() => {
+      navigate("/order/1");
+    }, 300);
+  };
+
+  const handleAddToCart = () => {
+    if (!isAuthenticated) {
+      setOpen(false);
+      setTimeout(() => {
+        openAuthDrawer("/cart");
+      }, 300);
+      return;
+    }
+
+    console.log("장바구니에 담김");
+  };
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
@@ -58,10 +81,14 @@ export default function ProductPurchaseDrawer({ open, setOpen, product }: Produc
           </div>
 
           <div className="grid grid-cols-2 gap-3 pt-4">
-            <Button className="h-12 text-base font-medium" onClick={() => setOpen(false)}>
+            <Button className="h-12 text-base font-medium" onClick={handlePurchase}>
               바로 구매
             </Button>
-            <Button className="h-12 rounded-lg border border-border bg-background text-foreground" variant="link">
+            <Button
+              className="h-12 rounded-lg border border-border bg-background text-foreground"
+              variant="link"
+              onClick={handleAddToCart}
+            >
               장바구니 담기
             </Button>
           </div>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,79 @@
+import { useAuth, useAuthenticatedNavigate } from "@/features/auth/hooks";
+import { Button } from "@/shared/components/ui/button";
+import { LoginLayout } from "@/shared/layout";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export default function LoginPage() {
+  const { isAuthenticated, login } = useAuth();
+  const navigate = useAuthenticatedNavigate();
+  const [searchParams] = useSearchParams();
+  const redirectTo = searchParams.get("redirect") ?? "/";
+
+  const handleLogin = () => {
+    login();
+  };
+
+  const handleCancel = () => {
+    navigate(-1);
+  };
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate(redirectTo, { replace: true });
+    }
+  }, [isAuthenticated, redirectTo, navigate]);
+
+  return (
+    <LoginLayout>
+      <div className="flex w-full flex-1 flex-col items-stretch justify-start gap-8 overflow-x-hidden bg-background px-4 pb-10 pt-8">
+        <div className="z-10 flex flex-1 flex-col items-center justify-between">
+          <div className="flex flex-col items-center justify-center gap-1">
+            <img
+              src="/logo.png"
+              alt="cotree 로고"
+              className="w-48 h-48 object-contain drop-shadow-lg select-none pointer-events-none"
+            />
+            <h1 className="text-2xl font-bold text-foreground mb-2">환영합니다!</h1>
+            <p className="text-muted-foreground text-center leading-relaxed">간편하게 로그인하고 이용해보세요</p>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col pt-8">
+          <div className="flex w-full flex-col items-center justify-center gap-3">
+            <div className="flex w-full flex-col items-center justify-center gap-3">
+              <div className="flex w-full flex-col items-center justify-center">
+                <Button
+                  className="relative w-full h-12 flex items-center justify-center p-4 border border-transparent text-base font-bold rounded-md text-black bg-[#FEE500] hover:bg-[#FEE500]/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FEE500]"
+                  size="lg"
+                  onClick={handleLogin}
+                >
+                  <img src="/kakao-icon.svg" alt="카카오 로고" className="w-6 h-56mr-2" width={20} height={20} />
+                  카카오로 로그인하기
+                </Button>
+              </div>
+            </div>
+            <div className="flex w-full flex-col items-center justify-center">
+              <Button
+                className="w-full h-12 px-4 py-3 text-gray-900 bg-gray-100 rounded-md hover:bg-gray-200"
+                size="lg"
+              >
+                게스트 계정으로 로그인하기
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex h-full w-full flex-row items-center justify-center gap-3 pt-5 text-muted-foreground">
+            <Button
+              onClick={handleCancel}
+              className="text-sm text-foreground cursor-pointer underline"
+              variant={"link"}
+            >
+              나중에 하기
+            </Button>
+          </div>
+        </div>
+      </div>
+    </LoginLayout>
+  );
+}

--- a/src/shared/layout/commonLayout.tsx
+++ b/src/shared/layout/commonLayout.tsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router-dom";
 import { Button } from "@/shared/components/ui/button";
 import { Search, ShoppingCart } from "lucide-react";
+import { AuthLink } from "@/features/auth/ui";
 
 interface CommonLayoutProps {
   children: React.ReactNode;
@@ -13,7 +13,7 @@ export default function CommonLayout({ children, title = "" }: CommonLayoutProps
       <header id="main-header" className="sticky top-0 z-20 flex w-full flex-col items-center justify-center">
         <div className="relative z-20 flex w-full max-w-limit flex-row items-center justify-between gap-4 transition-colors bg-white h-[52px] max-h-[52px] min-h-[52px] px-24">
           <div className="absolute bottom-0 left-3 top-0 flex flex-row items-center justify-center">
-            <Link to={"/"} className="fflex flex-1 items-center justify-center p-2">
+            <AuthLink to={"/"} className="fflex flex-1 items-center justify-center p-2">
               <span className="sr-only">Home</span>
               <img
                 src="/logo.png"
@@ -22,7 +22,7 @@ export default function CommonLayout({ children, title = "" }: CommonLayoutProps
                 alt="logo"
                 className="max-h-[52px] h-[52px] object-left pt-1"
               />
-            </Link>
+            </AuthLink>
           </div>
           <div className="flex-1 truncate text-center text-sm transition-colors text-muted-foreground font-bold">
             {title}
@@ -37,10 +37,10 @@ export default function CommonLayout({ children, title = "" }: CommonLayoutProps
               <span className="sr-only">Search</span>
               <Search className="!w-6 !h-6 text-black" />
             </Button>
-            <Link to={"/cart"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
+            <AuthLink to={"/cart"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
               <span className="sr-only">ShoppingCart</span>
               <ShoppingCart className="!w-6 !h-6 text-black" />
-            </Link>
+            </AuthLink>
           </div>
         </div>
       </header>

--- a/src/shared/layout/headerHomeLayout.tsx
+++ b/src/shared/layout/headerHomeLayout.tsx
@@ -1,6 +1,7 @@
-import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/shared/components/ui/button";
 import { ArrowLeft, Home } from "lucide-react";
+import { AuthLink } from "@/features/auth/ui";
+import { useAuthenticatedNavigate } from "@/features/auth/hooks/useAuthenticateNavigate";
 
 interface HeaderBackLayoutProps {
   children: React.ReactNode;
@@ -8,7 +9,7 @@ interface HeaderBackLayoutProps {
 }
 
 export default function HeaderHomeLayout({ children, title = "" }: HeaderBackLayoutProps) {
-  const navigate = useNavigate();
+  const navigate = useAuthenticatedNavigate();
 
   return (
     <div id="main-container" className="flex min-h-screen w-full flex-col items-center justify-start">
@@ -25,10 +26,10 @@ export default function HeaderHomeLayout({ children, title = "" }: HeaderBackLay
           </div>
 
           <div className="absolute bottom-0 right-4 top-0 flex flex-row items-center justify-center gap-4">
-            <Link to={"/"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
+            <AuthLink to={"/"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
               <span className="sr-only">홈</span>
               <Home className="!w-6 !h-6 text-black" />
-            </Link>
+            </AuthLink>
           </div>
         </div>
       </header>

--- a/src/shared/layout/index.tsx
+++ b/src/shared/layout/index.tsx
@@ -1,3 +1,4 @@
 export { default as CommonLayout } from "./commonLayout";
 export { default as HeaderBackLayout } from "./headerBackLayout";
 export { default as HeaderHomeLayout } from "./headerHomeLayout";
+export { default as LoginLayout } from "./loginLayout";

--- a/src/shared/layout/loginLayout.tsx
+++ b/src/shared/layout/loginLayout.tsx
@@ -1,42 +1,36 @@
-import { Button } from "@/shared/components/ui/button";
-import { ArrowLeft, ShoppingCart } from "lucide-react";
 import { AuthLink } from "@/features/auth/ui";
-import { useAuthenticatedNavigate } from "@/features/auth/hooks/useAuthenticateNavigate";
 
-interface HeaderBackLayoutProps {
+interface LoginLayoutProps {
   children: React.ReactNode;
   title?: string;
 }
 
-export default function HeaderBackLayout({ children, title = "" }: HeaderBackLayoutProps) {
-  const navigate = useAuthenticatedNavigate();
-
+export default function LoginLayout({ children, title = "" }: LoginLayoutProps) {
   return (
     <div id="main-container" className="flex min-h-screen w-full flex-col items-center justify-start">
       <header id="main-header" className="sticky top-0 z-20 flex w-full flex-col items-center justify-center">
         <div className="relative z-20 flex w-full max-w-limit flex-row items-center justify-between gap-4 transition-colors bg-white h-[52px] max-h-[52px] min-h-[52px] px-24">
           <div className="absolute bottom-0 left-3 top-0 flex flex-row items-center justify-center">
-            <Button onClick={() => navigate(-1)} className="w-8 h-8 p-2 cursor-pointer" variant={"link"}>
-              <span className="sr-only">뒤로가기</span>
-              <ArrowLeft className="w-5 h-5 text-black" />
-            </Button>
+            <AuthLink to={"/"} className="fflex flex-1 items-center justify-center p-2">
+              <span className="sr-only">Home</span>
+              <img
+                src="/logo.png"
+                width={60}
+                height={52}
+                alt="logo"
+                className="max-h-[52px] h-[52px] object-left pt-1"
+              />
+            </AuthLink>
           </div>
           <div className="flex-1 truncate text-center text-sm transition-colors text-muted-foreground font-bold">
             {title}
-          </div>
-
-          <div className="absolute bottom-0 right-4 top-0 flex flex-row items-center justify-center gap-4">
-            <AuthLink to={"/cart"} className="relative -m-2 flex h-10 w-10 items-center justify-center p-2">
-              <span className="sr-only">ShoppingCart</span>
-              <ShoppingCart className="!w-6 !h-6 text-black" />
-            </AuthLink>
           </div>
         </div>
       </header>
 
       <div
         id="main-content"
-        className="flex w-full max-w-limit flex-1 flex-col items-stretch justify-start pb-safe-bottom pb-16"
+        className="flex w-full max-w-limit flex-1 flex-col items-stretch justify-start pb-safe-bottom"
       >
         {children}
       </div>


### PR DESCRIPTION
<!-- 제목 입력하기 -->
<!-- [FEAT/CHORE/FIX/DOCS/REFACTOR] 기능제목 -->
[FEAT] 카카오 로그인, 프론트에서 하드코딩 로그인여부 체크

<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
 - `feat/kakaoLogin` -> `main`

## 🔗변경 사항
 - 카카오 로그인 연동 로직 추가
 - 프론트에서 `isAuthenticated` 하드코딩 방식으로 로그인 여부 임시 체크
 - 로그인 필요 시 Drawer 띄우는 로직 구현 (`openAuthDrawer` 사용)
 - URL로 직접 접근시 `/login`으로 리다이렉트

## ✔️테스트
 - [x] 비로그인 상태에서 구매하기 → 로그인 Drawer 호출 확인
 - [x] 장바구니 담기 시 로그인 여부 체크

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
