### PR TITLE
[REFACTOR] 주문서 UI 구조 개선 및 컴포넌트 네이밍 리팩토링

### DIFF
--- a/src/entities/order/ui/index.ts
+++ b/src/entities/order/ui/index.ts
@@ -1,3 +1,0 @@
-export { default as OrderProductListSection } from "./orderProductListSection";
-export { default as OrderPaymentMethodButtonList } from "./orderPaymentMethodButtonList";
-export { default as OrderPaymentTypeRadioGroup } from "./orderPaymentTypeRadioGroup";

--- a/src/features/order/ui/index.tsx
+++ b/src/features/order/ui/index.tsx
@@ -1,8 +1,12 @@
-export { default as OrderPaymentCardInformationFields } from "./orderPaymentCardInformationFields";
+export { default as OrderPaymentCardInputFields } from "./orderPaymentCardInputFields";
 export { default as OrderAgreementConfirmationCheckbox } from "./orderAgreementConfirmationCheckbox";
 export { default as OrderPaymentActionBar } from "./orderPaymentActionBar";
 export { default as OrderShippingAddressPostcode } from "./orderShippingAddressPostCode";
-export { default as OrderShippingAddressRegistrationSection } from "./orderShippingAddressRegistrationSection";
+export { default as OrderShippingAddressField } from "./orderShippingAddressField";
 export { default as OrderRecipientFields } from "./orderRecipientFields";
 export { default as OrderStatusContent } from "./orderStatusContent";
 export { default as OrderStatusList } from "./orderStatusList";
+export { default as OrderProductSummary } from "./orderProductSummary";
+export { default as OrderPaymentTypeOptions } from "./orderPaymentTypeOptions";
+export { default as OrderPaymentMethodSelector } from "./orderPaymentMethodSelector";
+export { default as OrderPaymentForm } from "./orderPaymentForm";

--- a/src/features/order/ui/orderAgreementConfirmationCheckbox.tsx
+++ b/src/features/order/ui/orderAgreementConfirmationCheckbox.tsx
@@ -11,11 +11,14 @@ export default function OrderAgreementConfirmationCheckbox({
   onChange,
 }: OrderAgreementConfirmationCheckboxProps) {
   return (
-    <div className="flex items-center gap-2">
-      <Checkbox id="agree" checked={checked} onCheckedChange={(value) => onChange(!!value)} />
-      <Label htmlFor="agree" className="text-sm text-muted-foreground">
-        주문 내용을 확인하였으며, 결제에 동의합니다.
-      </Label>
+    <div className="space-y-3">
+      <h2 className="font-semibold text-lg">주문 정보 확인</h2>
+      <div className="flex items-center gap-2">
+        <Checkbox id="agree" checked={checked} onCheckedChange={(value) => onChange(!!value)} />
+        <Label htmlFor="agree" className="text-sm text-muted-foreground">
+          주문 내용을 확인하였으며, 결제에 동의합니다.
+        </Label>
+      </div>
     </div>
   );
 }

--- a/src/features/order/ui/orderPaymentCardInputFields.tsx
+++ b/src/features/order/ui/orderPaymentCardInputFields.tsx
@@ -4,7 +4,7 @@ import { Label } from "@/shared/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/shared/components/ui/select";
 import { Controller, useFormContext } from "react-hook-form";
 
-export default function OrderPaymentCardInformationFields() {
+export default function OrderPaymentCardInputFields() {
   const { setValue, control, formState } = useFormContext();
   const { errors } = formState;
 

--- a/src/features/order/ui/orderPaymentForm.tsx
+++ b/src/features/order/ui/orderPaymentForm.tsx
@@ -1,0 +1,29 @@
+import { OrderPaymentCardInputFields, OrderPaymentMethodSelector, OrderPaymentTypeOptions } from "@/features/order/ui";
+
+interface OrderPaymentFormProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function OrderPaymentForm({ title, children }: OrderPaymentFormProps) {
+  return (
+    <div className="space-y-4">
+      <h2 className="font-semibold text-lg">{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+OrderPaymentForm.TypeOptions = function TypeOptions(props: React.ComponentProps<typeof OrderPaymentTypeOptions>) {
+  return <OrderPaymentTypeOptions {...props} />;
+};
+
+OrderPaymentForm.MethodSelector = function MethodSelector(
+  props: React.ComponentProps<typeof OrderPaymentMethodSelector>
+) {
+  return <OrderPaymentMethodSelector {...props} />;
+};
+
+OrderPaymentForm.CardFields = function CardFields() {
+  return <OrderPaymentCardInputFields />;
+};

--- a/src/features/order/ui/orderPaymentMethodSelector.tsx
+++ b/src/features/order/ui/orderPaymentMethodSelector.tsx
@@ -6,11 +6,11 @@ interface PaymentMethod {
   selected?: boolean;
 }
 
-interface OrderPaymentMethodButtonListProps {
+interface OrderPaymentMethodSelectorProps {
   methods: PaymentMethod[];
 }
 
-export default function OrderPaymentMethodButtonList({ methods }: OrderPaymentMethodButtonListProps) {
+export default function OrderPaymentMethodSelector({ methods }: OrderPaymentMethodSelectorProps) {
   return (
     <div className="grid grid-cols-3 gap-2">
       {methods.map(({ label, disabled, selected }) => (

--- a/src/features/order/ui/orderPaymentTypeOptions.tsx
+++ b/src/features/order/ui/orderPaymentTypeOptions.tsx
@@ -1,17 +1,13 @@
 import { RadioGroup, RadioGroupItem } from "@/shared/components/ui/radio-group";
 import { Label } from "@/shared/components/ui/label";
 
-interface OrderPaymentTypeRadioGroupProps {
+interface OrderPaymentTypeOptionsProps {
   value: string;
   disabled?: boolean;
   onChange?: (value: string) => void;
 }
 
-export default function OrderPaymentTypeRadioGroup({
-  value,
-  disabled = false,
-  onChange,
-}: OrderPaymentTypeRadioGroupProps) {
+export default function OrderPaymentTypeOptions({ value, disabled = false, onChange }: OrderPaymentTypeOptionsProps) {
   return (
     <RadioGroup value={value} onValueChange={onChange} disabled={disabled} className="flex items-center gap-2">
       <RadioGroupItem value="general" id="general" disabled={disabled} />

--- a/src/features/order/ui/orderProductSummary.tsx
+++ b/src/features/order/ui/orderProductSummary.tsx
@@ -8,11 +8,11 @@ interface OrderProduct {
   quantity: number;
 }
 
-interface OrderProductListSectionProps {
+interface OrderProductSummaryProps {
   products: OrderProduct[];
 }
 
-export default function OrderProductListSection({ products }: OrderProductListSectionProps) {
+export default function OrderProductSummary({ products }: OrderProductSummaryProps) {
   return (
     <section className="space-y-3">
       <h2 className="font-semibold text-lg">주문상품</h2>

--- a/src/features/order/ui/orderRecipientFields.tsx
+++ b/src/features/order/ui/orderRecipientFields.tsx
@@ -25,7 +25,7 @@ export default function OrderRecipientFields() {
   };
 
   return (
-    <section className="space-y-4">
+    <div className="space-y-4">
       <h2 className="font-semibold text-lg">받는 사람 정보</h2>
 
       <div className="space-y-2">
@@ -67,6 +67,6 @@ export default function OrderRecipientFields() {
           )}
         </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/src/features/order/ui/orderShippingAddressField.tsx
+++ b/src/features/order/ui/orderShippingAddressField.tsx
@@ -6,7 +6,7 @@ interface Props {
   children: (props: { open: boolean; setOpen: (v: boolean) => void; onSelect: (addr: string) => void }) => ReactNode;
 }
 
-export default function OrderShippingAddressRegistrationSection({ children }: Props) {
+export default function OrderShippingAddressField({ children }: Props) {
   const [open, setOpen] = useState(false);
   const [address, setAddress] = useState<string | null>(null);
 
@@ -20,7 +20,7 @@ export default function OrderShippingAddressRegistrationSection({ children }: Pr
 
   return (
     <>
-      <section className="space-y-3">
+      <div className="space-y-3">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold text-lg">배송지 정보</h2>
           <Button size="sm" variant="ghost" className="cursor-pointer" onClick={() => setOpen(true)}>
@@ -31,7 +31,7 @@ export default function OrderShippingAddressRegistrationSection({ children }: Pr
           {address ?? "배송지 정보가 없습니다. 배송지를 먼저 등록해주세요."}
         </p>
         {error && <p className="text-sm text-destructive">{error}</p>}
-      </section>
+      </div>
 
       {children({ open, setOpen, onSelect: handleSelect })}
     </>

--- a/src/pages/order/create/orderCreateView.tsx
+++ b/src/pages/order/create/orderCreateView.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { OrderPaymentMethodButtonList, OrderPaymentTypeRadioGroup, OrderProductListSection } from "@/entities/order/ui";
 import {
   OrderAgreementConfirmationCheckbox,
   OrderPaymentActionBar,
-  OrderPaymentCardInformationFields,
+  OrderPaymentForm,
+  OrderProductSummary,
   OrderRecipientFields,
+  OrderShippingAddressField,
   OrderShippingAddressPostcode,
-  OrderShippingAddressRegistrationSection,
 } from "@/features/order/ui";
 import { FormProvider, useForm } from "react-hook-form";
 import { orderFormSchema, OrderFormValues } from "@/features/order/model/schema";
@@ -80,17 +80,16 @@ export default function OrderCreateView() {
   return (
     <FormProvider {...methods}>
       <div className="w-full max-w-limit mx-auto px-4 py-6 space-y-8">
-        <OrderShippingAddressRegistrationSection>
+        <OrderShippingAddressField>
           {({ open, setOpen, onSelect }) => (
             <OrderShippingAddressPostcode open={open} setOpen={setOpen} onSelect={onSelect} />
           )}
-        </OrderShippingAddressRegistrationSection>
+        </OrderShippingAddressField>
         <OrderRecipientFields />
-        <OrderProductListSection products={products} />
-        <section className="space-y-4">
-          <h2 className="font-semibold text-lg">결제수단</h2>
-          <OrderPaymentTypeRadioGroup value="general" disabled={true} />
-          <OrderPaymentMethodButtonList
+        <OrderProductSummary products={products} />
+        <OrderPaymentForm title="결제수단">
+          <OrderPaymentForm.TypeOptions value="general" disabled />
+          <OrderPaymentForm.MethodSelector
             methods={[
               { label: "신용카드", disabled: false, selected: true },
               { label: "간편결제", disabled: true },
@@ -99,14 +98,9 @@ export default function OrderCreateView() {
               { label: "실시간 계좌이체", disabled: true },
             ]}
           />
-
-          <OrderPaymentCardInformationFields />
-        </section>
-
-        <section className="space-y-3">
-          <h2 className="font-semibold text-lg">주문 정보 확인</h2>
-          <OrderAgreementConfirmationCheckbox checked={isChecked} onChange={setIsChecked} />
-        </section>
+          <OrderPaymentForm.CardFields />
+        </OrderPaymentForm>
+        <OrderAgreementConfirmationCheckbox checked={isChecked} onChange={setIsChecked} />
       </div>
 
       <OrderPaymentActionBar totalAmount={total} disabled={!isChecked} onClick={methods.handleSubmit(onSubmit)} />


### PR DESCRIPTION
<!-- 제목 입력하기 -->
[REFACTOR] 주문서 UI 구조 개선 및 컴포넌트 네이밍 리팩토링


<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
- `refactor/declarative-order-form` -> `main`

## 🔗변경 사항
 - OrderPaymentForm 도입으로 결제 영역을 선언적으로 구성
 - TypeOptions, MethodSelector, CardFields 컴포넌트로 분리
 - OrderShippingAddressField 컴포넌트 도입 및 Postcode 연결 구조 개선

## ✔️테스트
 - [x] 주문서 내 모든 필드 입력 및 제출 테스트
 - [x] 배송지 등록 → 주소 반영 → 결제까지 흐름 확인
 - [x] UI 구조 변경 후 레이아웃 정상 렌더링 확인

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
