### PR TITLE
[FIX] iOS 크롬에서 하단 바텀 여백 문제 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="64x64" href="/favicon/favicon-64x64.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 viewport-fit=cover" />
     <title>cotree</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -52,10 +52,6 @@
   display: none;
 }
 
-.pb-safe-bottom {
-  padding-bottom: calc(env(safe-area-inset-bottom) + 0px);
-}
-
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,10 @@
   display: none;
 }
 
+.pb-safe-bottom {
+  padding-bottom: calc(env(safe-area-inset-bottom) + 0px);
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
<!-- 제목 입력하기 -->
[FIX] iOS 크롬에서 하단 바텀 여백 문제 해결

## ✈️브랜치
 - `refactor/bottom-tab` -> `main`

## 🔗변경 사항
 - `<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">` 추가
 - iOS Safari에서 `env(safe-area-inset-bottom)` 없이도 안전하게 화면 꽉 차게 렌더링됨
 - `.pb-safe-bottom` 등 불필요한 하단 패딩 제거 가능

## ✔️테스트
 - [x] iOS Safari에서 하단 여백 없음 확인
 - [x] Android Chrome, PC에서도 정상 동작
 - [x] fixed bottom UI 정상 위치 유지

<!-- close #이슈번호 (있으면 작성) -->