### PR TITLE
[FEAT] 나무 조회 후 성장 

### DIFF
--- a/src/entities/environment/api/get.ts
+++ b/src/entities/environment/api/get.ts
@@ -1,0 +1,15 @@
+import { BaseApiError, DisplayMode } from "@/shared/lib/api/errors/baseApiError";
+import { api } from "@/shared/lib/api/ky";
+import { MyTreeResponse } from "../model";
+
+export const getMyTree = async (displayMode: DisplayMode = "fallback") => {
+  try {
+    const response = await api.get("tree").json<{ data: MyTreeResponse }>();
+    return response.data;
+  } catch (err) {
+    if (err instanceof BaseApiError) {
+      err.displayMode = displayMode;
+    }
+    throw err;
+  }
+};

--- a/src/entities/environment/api/hooks.ts
+++ b/src/entities/environment/api/hooks.ts
@@ -1,0 +1,8 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { environmentQueryOptions } from "./queryOptions";
+import { DisplayMode } from "@/shared/lib/api/errors/baseApiError";
+import { MyTreeResponse } from "../model";
+
+export const useMyTree = (displayMode: DisplayMode = "fallback") => {
+  return useSuspenseQuery<MyTreeResponse>(environmentQueryOptions.getMyTree(displayMode));
+};

--- a/src/entities/environment/api/hooks.ts
+++ b/src/entities/environment/api/hooks.ts
@@ -1,8 +1,8 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { environmentQueryOptions } from "./queryOptions";
 import { DisplayMode } from "@/shared/lib/api/errors/baseApiError";
 import { MyTreeResponse } from "../model";
+import { useQuery } from "@tanstack/react-query";
 
 export const useMyTree = (displayMode: DisplayMode = "fallback") => {
-  return useSuspenseQuery<MyTreeResponse>(environmentQueryOptions.getMyTree(displayMode));
+  return useQuery<MyTreeResponse>(environmentQueryOptions.getMyTree(displayMode));
 };

--- a/src/entities/environment/api/queryOptions.ts
+++ b/src/entities/environment/api/queryOptions.ts
@@ -1,0 +1,16 @@
+import { DisplayMode } from "@/shared/lib/api/errors/baseApiError";
+import { getMyTree } from "./get";
+
+export const environmentKeys = {
+  myTree: ["environment", "myTree"] as const,
+};
+
+export const environmentQueryOptions = {
+  getMyTree: (displayMode: DisplayMode = "fallback") => ({
+    queryKey: environmentKeys.myTree,
+    queryFn: () => getMyTree(displayMode),
+    staleTime: 0,
+    gcTime: 0,
+    meta: { displayMode },
+  }),
+};

--- a/src/entities/environment/model/apiResponse.ts
+++ b/src/entities/environment/model/apiResponse.ts
@@ -1,0 +1,3 @@
+export interface MyTreeResponse {
+  exp: number;
+}

--- a/src/entities/environment/model/index.ts
+++ b/src/entities/environment/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./apiResponse";

--- a/src/features/environment/ui/loadingOverlay.tsx
+++ b/src/features/environment/ui/loadingOverlay.tsx
@@ -11,7 +11,7 @@ function LoadingOverlay({ children }: LoadingOverlayRootProps) {
 
 LoadingOverlay.WhenLoading = function WhenLoading({ children }: { children: React.ReactNode }) {
   const { isReady } = useEnvironmentContext();
-  const showOverlay = useDelayedUnmount(!isReady, 1000);
+  const showOverlay = useDelayedUnmount(!isReady, 200);
 
   if (!showOverlay) return null;
 

--- a/src/features/environment/ui/loadingOverlay.tsx
+++ b/src/features/environment/ui/loadingOverlay.tsx
@@ -11,7 +11,7 @@ function LoadingOverlay({ children }: LoadingOverlayRootProps) {
 
 LoadingOverlay.WhenLoading = function WhenLoading({ children }: { children: React.ReactNode }) {
   const { isReady } = useEnvironmentContext();
-  const showOverlay = useDelayedUnmount(!isReady, 200);
+  const showOverlay = useDelayedUnmount(!isReady, 400);
 
   if (!showOverlay) return null;
 

--- a/src/pages/mypage/environment/environmentView.tsx
+++ b/src/pages/mypage/environment/environmentView.tsx
@@ -1,0 +1,46 @@
+import { useMyTree } from "@/entities/environment/api/hooks";
+import { EnvironmentProvider } from "@/features/environment/context";
+import { EnvironmentCanvas } from "@/features/environment/ui";
+import { TreeActionBar } from "@/features/environment/ui/treeActionBar";
+import { EnvironmentLayout } from "@/shared/layout";
+import LoadingOverlay from "@/features/environment/ui/loadingOverlay";
+
+export default function EnvironmentView() {
+  const { data, isLoading } = useMyTree();
+
+  if (isLoading || !data) {
+    return (
+      <EnvironmentLayout>
+        <LoadingOverlay>
+          <div className="w-full max-w-limit mx-auto fixed inset-0 z-50 bg-background/30 backdrop-blur-xs flex items-center justify-center transition-opacity duration-700">
+            <LoadingOverlay.Loading />
+          </div>
+        </LoadingOverlay>
+      </EnvironmentLayout>
+    );
+  }
+
+  return (
+    <EnvironmentProvider initialExp={data.exp}>
+      <EnvironmentCanvas />
+
+      <TreeActionBar>
+        {({ visible }) => (
+          <>
+            <TreeActionBar.Level />
+            <TreeActionBar.Progress />
+            <TreeActionBar.Buttons visible={visible}>
+              <TreeActionBar.GiveWater />
+            </TreeActionBar.Buttons>
+          </>
+        )}
+      </TreeActionBar>
+
+      <LoadingOverlay>
+        <LoadingOverlay.WhenLoading>
+          <LoadingOverlay.Loading />
+        </LoadingOverlay.WhenLoading>
+      </LoadingOverlay>
+    </EnvironmentProvider>
+  );
+}

--- a/src/pages/mypage/environment/index.tsx
+++ b/src/pages/mypage/environment/index.tsx
@@ -1,16 +1,33 @@
+import { Suspense } from "react";
+import { useMyTree } from "@/entities/environment/api/hooks";
 import { EnvironmentProvider } from "@/features/environment/context";
-import { EnvironmentCanvas, LoadingOverlay } from "@/features/environment/ui";
+import { EnvironmentCanvas } from "@/features/environment/ui";
 import { TreeActionBar } from "@/features/environment/ui/treeActionBar";
-import { EnvironmentLayout } from "@/shared/layout/";
+import { EnvironmentLayout } from "@/shared/layout";
+import { useEnvironmentContext } from "@/features/environment/hooks";
+import { ErrorFallback } from "@/shared/components";
+import { ErrorBoundary } from "react-error-boundary";
+import LoadingOverlay from "@/features/environment/ui/loadingOverlay";
 
-export default function EnvironmentPage() {
-  const exp = 0;
+function EnvironmentContainer() {
+  const {
+    data: { exp },
+  } = useMyTree();
 
   return (
     <EnvironmentProvider initialExp={exp}>
-      <EnvironmentLayout>
-        <EnvironmentCanvas />
+      <CanvasWithUI />
+    </EnvironmentProvider>
+  );
+}
 
+function CanvasWithUI() {
+  const { isReady } = useEnvironmentContext();
+
+  return (
+    <>
+      <EnvironmentCanvas />
+      {isReady && (
         <TreeActionBar>
           {({ visible }) => (
             <>
@@ -22,12 +39,32 @@ export default function EnvironmentPage() {
             </>
           )}
         </TreeActionBar>
-        <LoadingOverlay>
-          <LoadingOverlay.WhenLoading>
-            <LoadingOverlay.Loading />
-          </LoadingOverlay.WhenLoading>
-        </LoadingOverlay>
-      </EnvironmentLayout>
-    </EnvironmentProvider>
+      )}
+      <LoadingOverlay>
+        <LoadingOverlay.WhenLoading>
+          <LoadingOverlay.Loading />
+        </LoadingOverlay.WhenLoading>
+      </LoadingOverlay>
+    </>
+  );
+}
+
+export default function EnvironmentPage() {
+  return (
+    <EnvironmentLayout>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Suspense
+          fallback={
+            <LoadingOverlay>
+              <div className="w-full max-w-limit mx-auto fixed inset-0 z-50 bg-background/30 backdrop-blur-xs flex items-center justify-center transition-opacity duration-700">
+                <LoadingOverlay.Loading />
+              </div>
+            </LoadingOverlay>
+          }
+        >
+          <EnvironmentContainer />
+        </Suspense>
+      </ErrorBoundary>
+    </EnvironmentLayout>
   );
 }

--- a/src/pages/mypage/environment/index.tsx
+++ b/src/pages/mypage/environment/index.tsx
@@ -1,69 +1,13 @@
-import { Suspense } from "react";
-import { useMyTree } from "@/entities/environment/api/hooks";
-import { EnvironmentProvider } from "@/features/environment/context";
-import { EnvironmentCanvas } from "@/features/environment/ui";
-import { TreeActionBar } from "@/features/environment/ui/treeActionBar";
 import { EnvironmentLayout } from "@/shared/layout";
-import { useEnvironmentContext } from "@/features/environment/hooks";
 import { ErrorFallback } from "@/shared/components";
 import { ErrorBoundary } from "react-error-boundary";
-import LoadingOverlay from "@/features/environment/ui/loadingOverlay";
-
-function EnvironmentContainer() {
-  const {
-    data: { exp },
-  } = useMyTree();
-
-  return (
-    <EnvironmentProvider initialExp={exp}>
-      <CanvasWithUI />
-    </EnvironmentProvider>
-  );
-}
-
-function CanvasWithUI() {
-  const { isReady } = useEnvironmentContext();
-
-  return (
-    <>
-      <EnvironmentCanvas />
-      {isReady && (
-        <TreeActionBar>
-          {({ visible }) => (
-            <>
-              <TreeActionBar.Level />
-              <TreeActionBar.Progress />
-              <TreeActionBar.Buttons visible={visible}>
-                <TreeActionBar.GiveWater />
-              </TreeActionBar.Buttons>
-            </>
-          )}
-        </TreeActionBar>
-      )}
-      <LoadingOverlay>
-        <LoadingOverlay.WhenLoading>
-          <LoadingOverlay.Loading />
-        </LoadingOverlay.WhenLoading>
-      </LoadingOverlay>
-    </>
-  );
-}
+import EnvironmentView from "./environmentView";
 
 export default function EnvironmentPage() {
   return (
     <EnvironmentLayout>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
-        <Suspense
-          fallback={
-            <LoadingOverlay>
-              <div className="w-full max-w-limit mx-auto fixed inset-0 z-50 bg-background/30 backdrop-blur-xs flex items-center justify-center transition-opacity duration-700">
-                <LoadingOverlay.Loading />
-              </div>
-            </LoadingOverlay>
-          }
-        >
-          <EnvironmentContainer />
-        </Suspense>
+        <EnvironmentView />
       </ErrorBoundary>
     </EnvironmentLayout>
   );

--- a/src/shared/lib/api/errors/environmentApiError.ts
+++ b/src/shared/lib/api/errors/environmentApiError.ts
@@ -1,0 +1,9 @@
+import { BaseApiError } from "./baseApiError";
+import { EnvironmentError, EnvironmentErrorCode } from "./environmentErrorCode";
+
+export class EnvironmentApiError extends BaseApiError {
+  constructor(code: EnvironmentErrorCode, status: number) {
+    const { message } = EnvironmentError[code];
+    super(code, message, status);
+  }
+}

--- a/src/shared/lib/api/errors/environmentErrorCode.ts
+++ b/src/shared/lib/api/errors/environmentErrorCode.ts
@@ -1,0 +1,24 @@
+export const EnvironmentError = {
+  TR001: {
+    code: "TR001",
+    devMessage: "트리를 찾을 수 없습니다.",
+    message: "내 나무 정보를 찾을 수 없습니다.",
+  },
+  TR002: {
+    code: "TR002",
+    devMessage: "트리 생성 실패 - DB 저장 오류",
+    message: "나무 생성에 실패했습니다.",
+  },
+  TR003: {
+    code: "TR003",
+    devMessage: "트리 경험치 업데이트 실패 - update 쿼리 실패",
+    message: "경험치 업데이트에 실패했습니다.",
+  },
+  TR004: {
+    code: "TR004",
+    devMessage: "잘못된 경험치 값 - 음수 혹은 null",
+    message: "잘못된 경험치 값입니다.",
+  },
+} as const;
+
+export type EnvironmentErrorCode = keyof typeof EnvironmentError;

--- a/src/shared/lib/api/errors/index.ts
+++ b/src/shared/lib/api/errors/index.ts
@@ -2,3 +2,5 @@ export * from "./auhErrorCode";
 export * from "./authApiError";
 export * from "./cartErrorCode";
 export * from "./cartApiError";
+export * from "./environmentErrorCode";
+export * from "./environmentApiError";

--- a/src/shared/lib/api/ky.ts
+++ b/src/shared/lib/api/ky.ts
@@ -1,5 +1,14 @@
 import ky from "ky";
-import { AuthApiError, AuthErrorCode, CartApiError, CartError, CartErrorCode } from "@/shared/lib/api/errors";
+import {
+  AuthApiError,
+  AuthErrorCode,
+  CartApiError,
+  CartError,
+  CartErrorCode,
+  EnvironmentApiError,
+  EnvironmentError,
+  EnvironmentErrorCode,
+} from "@/shared/lib/api/errors";
 import { refreshAccessToken } from "@/shared/lib/api/auth";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -40,6 +49,10 @@ export const api = ky.create({
 
           if (code in CartError) {
             throw new CartApiError(code as CartErrorCode, status);
+          }
+
+          if (code in EnvironmentError) {
+            throw new EnvironmentApiError(code as EnvironmentErrorCode, status);
           }
 
           throw new Error("알 수 없는 에러가 발생했습니다.");


### PR DESCRIPTION
[FEAT] 나무 성장 페이지 초기 구성 및 에러 처리 구조 도입

## ✈️브랜치
 - feat/environment-> main

## 🔗변경 사항
 - `EnvironmentPage` → 레이아웃 + 에러 바운더리 분리
 - `EnvironmentView` → useQuery 기반 데이터 패칭 및 렌더링 분기 처리
 - `EnvironmentProvider`로 exp 상태 주입
 - `TreeActionBar`, `EnvironmentCanvas`, `LoadingOverlay` 선언형 구조로 구성
 - `ErrorFallback`을 통한 에러 복구 UI 구현
 - Suspense 제거, 명시적 로딩 처리 방식 적용

## ✔️테스트
 - [x] 로딩 시 `LoadingOverlay` 정상 작동
 - [x] API 실패 시 `ErrorFallback`에서 재시도 가능
 - [x] exp 패칭 후 나무 UI 정상 렌더링됨

<!-- close #이슈번호가 있다면 여기에 작성 -->
#27 