### PR TITLE
[FEAT] 나무 성장

### DIFF
--- a/src/entities/environment/api/hooks.ts
+++ b/src/entities/environment/api/hooks.ts
@@ -1,8 +1,27 @@
 import { environmentQueryOptions } from "./queryOptions";
 import { DisplayMode } from "@/shared/lib/api/errors/baseApiError";
-import { MyTreeResponse } from "../model";
-import { useQuery } from "@tanstack/react-query";
+import { GiveWaterRequest, GiveWaterResponse, MyTreeResponse } from "../model";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEnvironmentContext } from "@/features/environment/hooks";
+import { giveWater } from "./update";
+import { MAX_EXP } from "../constants";
 
 export const useMyTree = (displayMode: DisplayMode = "fallback") => {
   return useQuery<MyTreeResponse>(environmentQueryOptions.getMyTree(displayMode));
+};
+
+export const useGiveWater = (displayMode: DisplayMode = "toast") => {
+  const { exp, setExp, setRemainingWaterUnit, syncGrowthFromExp } = useEnvironmentContext();
+
+  return useMutation<GiveWaterResponse, Error, GiveWaterRequest>({
+    mutationFn: (payload) => giveWater(payload, displayMode),
+
+    onSuccess: ({ exp: serverExp, remainingWaterUnit: serverUnit }) => {
+      if (serverExp >= MAX_EXP && exp >= MAX_EXP) return;
+
+      setExp(serverExp);
+      syncGrowthFromExp(serverExp);
+      setRemainingWaterUnit(serverUnit);
+    },
+  });
 };

--- a/src/entities/environment/api/hooks.ts
+++ b/src/entities/environment/api/hooks.ts
@@ -23,5 +23,7 @@ export const useGiveWater = (displayMode: DisplayMode = "toast") => {
       syncGrowthFromExp(serverExp);
       setRemainingWaterUnit(serverUnit);
     },
+
+    meta: { displayMode, position: "top-right" },
   });
 };

--- a/src/entities/environment/api/update.ts
+++ b/src/entities/environment/api/update.ts
@@ -2,12 +2,18 @@ import { api } from "@/shared/lib/api/ky";
 import { GiveWaterRequest, GiveWaterResponse } from "../model";
 import { BaseApiError, DisplayMode } from "@/shared/lib/api/errors/baseApiError";
 
+const ACTION_ENDPOINT_MAP: Record<GiveWaterRequest["action"], string> = {
+  GIVE_WATER: "tree/water",
+  GIVE_ALL_WATER: "tree/water-all",
+};
+
 export const giveWater = async (
   payload: GiveWaterRequest,
-  displayMode: DisplayMode = "fallback"
+  displayMode: DisplayMode = "toast"
 ): Promise<GiveWaterResponse> => {
   try {
-    const response = await api.post("tree", { json: payload }).json<{ data: GiveWaterResponse }>();
+    const url = ACTION_ENDPOINT_MAP[payload.action];
+    const response = await api.post(url, { json: payload }).json<{ data: GiveWaterResponse }>();
     return response.data;
   } catch (err) {
     if (err instanceof BaseApiError) {

--- a/src/entities/environment/api/update.ts
+++ b/src/entities/environment/api/update.ts
@@ -1,0 +1,18 @@
+import { api } from "@/shared/lib/api/ky";
+import { GiveWaterRequest, GiveWaterResponse } from "../model";
+import { BaseApiError, DisplayMode } from "@/shared/lib/api/errors/baseApiError";
+
+export const giveWater = async (
+  payload: GiveWaterRequest,
+  displayMode: DisplayMode = "fallback"
+): Promise<GiveWaterResponse> => {
+  try {
+    const response = await api.post("tree", { json: payload }).json<{ data: GiveWaterResponse }>();
+    return response.data;
+  } catch (err) {
+    if (err instanceof BaseApiError) {
+      err.displayMode = displayMode;
+    }
+    throw err;
+  }
+};

--- a/src/entities/environment/constants/index.ts
+++ b/src/entities/environment/constants/index.ts
@@ -1,0 +1,1 @@
+export const MAX_EXP = 10000;

--- a/src/entities/environment/model/apiRequest.ts
+++ b/src/entities/environment/model/apiRequest.ts
@@ -1,0 +1,3 @@
+export type GiveWaterRequest = {
+  action: "GIVE_WATER" | "GIVE_ALL_WATER";
+};

--- a/src/entities/environment/model/apiResponse.ts
+++ b/src/entities/environment/model/apiResponse.ts
@@ -1,3 +1,4 @@
 export interface MyTreeResponse {
   exp: number;
+  remainingWaterUnit: number;
 }

--- a/src/entities/environment/model/apiResponse.ts
+++ b/src/entities/environment/model/apiResponse.ts
@@ -1,4 +1,7 @@
-export interface MyTreeResponse {
+export interface TreeStatus {
   exp: number;
   remainingWaterUnit: number;
 }
+
+export type MyTreeResponse = TreeStatus;
+export type GiveWaterResponse = TreeStatus;

--- a/src/entities/environment/model/index.ts
+++ b/src/entities/environment/model/index.ts
@@ -1,1 +1,2 @@
 export * from "./apiResponse";
+export * from "./apiRequest";

--- a/src/features/environment/context/environmentContext.ts
+++ b/src/features/environment/context/environmentContext.ts
@@ -5,7 +5,8 @@ import type { Tree } from "@/entities/environment/tree";
 export interface EnvironmentContextValue {
   exp: number;
   setExp: (v: number) => void;
-  increaseExp: (amount: number) => void;
+  syncGrowthFromExp: (exp: number) => void;
+  setRemainingWaterUnit: (v: number) => void;
   remainingWaterUnit: number;
   baseTreeRef: RefObject<Tree | null>;
   grassRef: RefObject<Grass | null>;

--- a/src/features/environment/context/environmentContext.ts
+++ b/src/features/environment/context/environmentContext.ts
@@ -6,6 +6,7 @@ export interface EnvironmentContextValue {
   exp: number;
   setExp: (v: number) => void;
   increaseExp: (amount: number) => void;
+  remainingWaterUnit: number;
   baseTreeRef: RefObject<Tree | null>;
   grassRef: RefObject<Grass | null>;
   isReady: boolean;

--- a/src/features/environment/context/environmentProvider.tsx
+++ b/src/features/environment/context/environmentProvider.tsx
@@ -22,29 +22,23 @@ export default function EnvironmentProvider({
   const grassRef = useRef<Grass>(null);
   const [isReady, setIsReady] = useState(false);
 
-  const increaseExp = useCallback(
-    (amount: number) => {
-      const newExp = exp + amount;
-      setExp(newExp);
-      setRemainingWaterUnit((prev) => Math.max(prev - 1, 0));
+  const syncGrowthFromExp = useCallback((exp: number) => {
+    const baseTree = baseTreeRef.current;
+    const grass = grassRef.current;
 
-      const baseTree = baseTreeRef.current;
-      const grass = grassRef.current;
+    if (!baseTree || !grass) return;
 
-      if (!baseTree || !grass) return;
-
-      baseTree.queueGrowthFromExp(newExp);
-      const targetGrassAmount = calculateGrassAmount(newExp);
-      grass.setGrassAmount(targetGrassAmount);
-    },
-    [exp]
-  );
+    baseTree.queueGrowthFromExp(exp);
+    const targetGrassAmount = calculateGrassAmount(exp);
+    grass.setGrassAmount(targetGrassAmount);
+  }, []);
 
   const value: EnvironmentContextValue = {
     exp,
     setExp,
     remainingWaterUnit,
-    increaseExp,
+    setRemainingWaterUnit,
+    syncGrowthFromExp,
     baseTreeRef,
     grassRef,
     isReady,

--- a/src/features/environment/context/environmentProvider.tsx
+++ b/src/features/environment/context/environmentProvider.tsx
@@ -7,10 +7,16 @@ import type { Grass } from "@/entities/environment/grass";
 interface EnvironmentProviderProps {
   children: React.ReactNode;
   initialExp: number;
+  initialRemainingWaterUnit: number;
 }
 
-export default function EnvironmentProvider({ children, initialExp }: EnvironmentProviderProps) {
+export default function EnvironmentProvider({
+  children,
+  initialExp,
+  initialRemainingWaterUnit,
+}: EnvironmentProviderProps) {
   const [exp, setExp] = useState(initialExp);
+  const [remainingWaterUnit, setRemainingWaterUnit] = useState(initialRemainingWaterUnit);
 
   const baseTreeRef = useRef<Tree>(null);
   const grassRef = useRef<Grass>(null);
@@ -20,6 +26,7 @@ export default function EnvironmentProvider({ children, initialExp }: Environmen
     (amount: number) => {
       const newExp = exp + amount;
       setExp(newExp);
+      setRemainingWaterUnit((prev) => Math.max(prev - 1, 0));
 
       const baseTree = baseTreeRef.current;
       const grass = grassRef.current;
@@ -36,6 +43,7 @@ export default function EnvironmentProvider({ children, initialExp }: Environmen
   const value: EnvironmentContextValue = {
     exp,
     setExp,
+    remainingWaterUnit,
     increaseExp,
     baseTreeRef,
     grassRef,

--- a/src/features/environment/ui/treeActionBar.tsx
+++ b/src/features/environment/ui/treeActionBar.tsx
@@ -1,6 +1,7 @@
 import { useEnvironmentContext } from "@/features/environment/hooks";
 import { calculateExpPercent } from "@/features/environment/utils";
 import { Button } from "@/shared/components/ui/button";
+import { cn } from "@/shared/lib/utils";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 
@@ -62,12 +63,17 @@ TreeActionBar.Buttons = function Buttons({ children, visible }: { children: Reac
 };
 
 TreeActionBar.GiveWater = function GiveWater() {
-  const { isReady, increaseExp } = useEnvironmentContext();
+  const { isReady, increaseExp, remainingWaterUnit } = useEnvironmentContext();
+  const isDisabled = !isReady || remainingWaterUnit <= 0;
 
   return (
-    <Button onClick={() => increaseExp(100)} disabled={!isReady} variant="default" className="cursor-pointer">
-      <span className="text-sm font-medium text-white">물 주기</span>
-      <span className="text-xs text-foreground/70 mt-0.5">3개 남음</span>
+    <Button
+      onClick={() => increaseExp(100)}
+      disabled={isDisabled}
+      variant="default"
+      className={cn("h-12", isDisabled ? "cursor-not-allowed" : "cursor-pointer")}
+    >
+      물주기 ({remainingWaterUnit}번 남았어요)
     </Button>
   );
 };

--- a/src/features/environment/ui/treeActionBar.tsx
+++ b/src/features/environment/ui/treeActionBar.tsx
@@ -1,3 +1,5 @@
+import { useGiveWater } from "@/entities/environment/api/hooks";
+import { MAX_EXP } from "@/entities/environment/constants";
 import { useEnvironmentContext } from "@/features/environment/hooks";
 import { calculateExpPercent } from "@/features/environment/utils";
 import { Button } from "@/shared/components/ui/button";
@@ -20,7 +22,7 @@ export function TreeActionBar({ children }: TreeActionBarProps) {
         ${visible ? "translate-y-0" : "translate-y-[calc(100%-4rem)]"}
       `}
     >
-      <div className="relative mx-auto max-w-limit rounded-t bg-background/90 backdrop-blur-md shadow-lg px-4 pt-4 pb-8 space-y-4">
+      <div className="relative mx-auto max-w-limit bg-background/90 backdrop-blur-md shadow-lg px-4 pt-4 pb-4 space-y-4">
         <div className="absolute -top-5 left-1/2 -translate-x-1/2 z-50">
           <Button
             size="icon"
@@ -59,21 +61,42 @@ TreeActionBar.Progress = function Progress() {
 TreeActionBar.Buttons = function Buttons({ children, visible }: { children: React.ReactNode; visible: boolean }) {
   if (!visible) return null;
 
-  return <div className="grid grid-cols-1 gap-3">{children}</div>;
+  return <div className="grid grid-cols-2 gap-3">{children}</div>;
 };
 
 TreeActionBar.GiveWater = function GiveWater() {
-  const { isReady, increaseExp, remainingWaterUnit } = useEnvironmentContext();
-  const isDisabled = !isReady || remainingWaterUnit <= 0;
+  const { isReady, remainingWaterUnit, exp } = useEnvironmentContext();
+  const { mutate: giveWater, isPending } = useGiveWater();
+  const isDisabled = !isReady || remainingWaterUnit <= 0 || exp >= MAX_EXP;
 
   return (
-    <Button
-      onClick={() => increaseExp(100)}
-      disabled={isDisabled}
-      variant="default"
-      className={cn("h-12", isDisabled ? "cursor-not-allowed" : "cursor-pointer")}
-    >
-      물주기 ({remainingWaterUnit}번 남았어요)
-    </Button>
+    <>
+      <Button
+        onClick={() => giveWater({ action: "GIVE_WATER" })}
+        disabled={isDisabled || isPending}
+        variant="default"
+        className={cn(
+          "h-12 relative",
+          "flex flex-col justify-center items-center leading-tight gap-0.5",
+          isDisabled || isPending ? "!cursor-not-allowed opacity-80" : "cursor-pointer"
+        )}
+      >
+        <span className="text-sm font-medium leading-none">{isPending ? "물 주는 중..." : "물 주기"}</span>
+        <span className="text-xs text-foreground leading-none">{remainingWaterUnit}회 가능</span>
+      </Button>
+      <Button
+        onClick={() => giveWater({ action: "GIVE_ALL_WATER" })}
+        disabled={isDisabled}
+        variant="outline"
+        className={cn(
+          "h-12",
+          "flex flex-col justify-center items-center leading-tight gap-0.5",
+          isDisabled || isPending ? "!cursor-not-allowed opacity-80" : "cursor-pointer"
+        )}
+      >
+        <span className="text-sm font-medium leading-none">🌧️ 비 내리기</span>
+        <span className="text-xs text-muted-foreground leading-none">모든 포인트 사용</span>
+      </Button>
+    </>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,8 +13,9 @@ const queryClient = new QueryClient({
     onError: (error, _variables, _context, mutation) => {
       if (error instanceof BaseApiError) {
         const mode = mutation.meta?.displayMode;
+        const position = mutation.meta?.position ? "top-right" : "bottom-right";
         if (mode === "toast") {
-          toast.error(error.message);
+          toast.error(error.message, { position: position });
         }
       }
     },

--- a/src/pages/mypage/environment/environmentView.tsx
+++ b/src/pages/mypage/environment/environmentView.tsx
@@ -8,7 +8,6 @@ import LoadingOverlay from "@/features/environment/ui/loadingOverlay";
 export default function EnvironmentView() {
   const { data, isLoading } = useMyTree();
 
-  console.log(data);
   if (isLoading || !data) {
     return (
       <EnvironmentLayout>

--- a/src/pages/mypage/environment/environmentView.tsx
+++ b/src/pages/mypage/environment/environmentView.tsx
@@ -8,6 +8,7 @@ import LoadingOverlay from "@/features/environment/ui/loadingOverlay";
 export default function EnvironmentView() {
   const { data, isLoading } = useMyTree();
 
+  console.log(data);
   if (isLoading || !data) {
     return (
       <EnvironmentLayout>
@@ -21,7 +22,7 @@ export default function EnvironmentView() {
   }
 
   return (
-    <EnvironmentProvider initialExp={data.exp}>
+    <EnvironmentProvider initialExp={data.exp} initialRemainingWaterUnit={data.remainingWaterUnit}>
       <EnvironmentCanvas />
 
       <TreeActionBar>

--- a/src/shared/lib/api/errors/environmentErrorCode.ts
+++ b/src/shared/lib/api/errors/environmentErrorCode.ts
@@ -19,6 +19,16 @@ export const EnvironmentError = {
     devMessage: "잘못된 경험치 값 - 음수 혹은 null",
     message: "잘못된 경험치 값입니다.",
   },
+  TR005: {
+    code: "TR005",
+    devMessage: "잘못된 액션 - 존재하지 않는 명령",
+    message: "유효하지 않은 요청입니다.",
+  },
+  TR006: {
+    code: "TR006",
+    devMessage: "트리 최대 경험치 도달",
+    message: "더 이상 성장할 수 없습니다.",
+  },
 } as const;
 
 export type EnvironmentErrorCode = keyof typeof EnvironmentError;

--- a/src/shared/lib/api/errors/greenPointApiError.ts
+++ b/src/shared/lib/api/errors/greenPointApiError.ts
@@ -1,0 +1,9 @@
+import { BaseApiError } from "./baseApiError";
+import { GreenPointError, GreenPointErrorCode } from "./greenPointErrorCode";
+
+export class GreenPointApiError extends BaseApiError {
+  constructor(code: GreenPointErrorCode, status: number) {
+    const { message } = GreenPointError[code];
+    super(code, message, status);
+  }
+}

--- a/src/shared/lib/api/errors/greenPointErrorCode.ts
+++ b/src/shared/lib/api/errors/greenPointErrorCode.ts
@@ -1,0 +1,14 @@
+export const GreenPointError = {
+  GP001: {
+    code: "GP001",
+    devMessage: "사용 가능한 포인트가 부족함",
+    message: "포인트가 부족합니다.",
+  },
+  GP002: {
+    code: "GP002",
+    devMessage: "포인트 로그 저장 실패",
+    message: "포인트 처리 중 문제가 발생했습니다.",
+  },
+} as const;
+
+export type GreenPointErrorCode = keyof typeof GreenPointError;

--- a/src/shared/lib/api/errors/index.ts
+++ b/src/shared/lib/api/errors/index.ts
@@ -4,3 +4,5 @@ export * from "./cartErrorCode";
 export * from "./cartApiError";
 export * from "./environmentErrorCode";
 export * from "./environmentApiError";
+export * from "./greenPointErrorCode";
+export * from "./greenPointApiError";

--- a/src/shared/lib/api/ky.ts
+++ b/src/shared/lib/api/ky.ts
@@ -8,6 +8,9 @@ import {
   EnvironmentApiError,
   EnvironmentError,
   EnvironmentErrorCode,
+  GreenPointApiError,
+  GreenPointError,
+  GreenPointErrorCode,
 } from "@/shared/lib/api/errors";
 import { refreshAccessToken } from "@/shared/lib/api/auth";
 
@@ -53,6 +56,10 @@ export const api = ky.create({
 
           if (code in EnvironmentError) {
             throw new EnvironmentApiError(code as EnvironmentErrorCode, status);
+          }
+
+          if (code in GreenPointError) {
+            throw new GreenPointApiError(code as GreenPointErrorCode, status);
           }
 
           throw new Error("알 수 없는 에러가 발생했습니다.");


### PR DESCRIPTION
<!-- 제목 입력하기 -->
[FEAT] 나무 성장

<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
 - feat/update-tree -> main

## 🔗변경 사항
- 물주기(`GIVE_WATER`)와 전체 물주기(`GIVE_ALL_WATER`)를 `ACTION_ENDPOINT_MAP`을 통해 추상화
- `giveWater` API 함수 내부에서 액션 타입에 따라 URL을 자동 매핑하도록 구조 개선
- displayMode를 에러 처리 흐름에서 활용할 수 있도록 개선

## ✔️테스트
 - [x] 물 한 번 주기 정상 동작 확인
 - [x] 전체 물주기 정상 동작 확인
 - [x] 잘못된 요청 시 toast 에러 메시지 출력 확인 (displayMode: "toast")
 - [x] fallback 처리 상황에서의 에러 흐름 정상 작동 확인

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
